### PR TITLE
Update Customer updateSubscription method to work

### DIFF
--- a/lib/Stripe/Customer.php
+++ b/lib/Stripe/Customer.php
@@ -74,10 +74,10 @@ class Stripe_Customer extends Stripe_ApiResource
     return $charges;
   }
 
-  public function updateSubscription($params=null)
+  public function updateSubscription($subscription, $params=null)
   {
     $requestor = new Stripe_ApiRequestor($this->_apiKey);
-    $url = $this->instanceUrl() . '/subscription';
+    $url = $this->instanceUrl() . '/subscriptions/' . $subscription;
     list($response, $apiKey) = $requestor->request('post', $url, $params);
     $this->refreshFrom(array('subscription' => $response), $apiKey, true);
     return $this->subscription;


### PR DESCRIPTION
This is how I was able to get the updateSubscription() method to work properly. Before, when calling the method, it would require a plan and then just create a new subscription with the proposed changes. This update will actually update the specific subscription.